### PR TITLE
dont edit microservice deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ turbolift_internals = { path="./turbolift_internals" }
 async-std = { version="1.6" }
 chrono = "0.4"
 cached = "0.19"
+actix-web = "3"
+serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+pub use actix_web;
 pub use async_std;
 pub use cached;
 pub use chrono;
+pub use serde_json;
 pub use turbolift_internals::*;
 pub use turbolift_macros::*;
 

--- a/turbolift_internals/src/build_project.rs
+++ b/turbolift_internals/src/build_project.rs
@@ -15,32 +15,11 @@ pub fn edit_cargo_file(cargo_path: &Path, function_name: &str) -> anyhow::Result
     // change name
     parsed_toml.package.name = function_name.to_string() + "_turbolift";
 
-    // add deps
-    let new_deps = vec![
-        ("actix-web", "2"),
-        ("actix-rt", "1"),
-        ("serde_json", "1"),
-        ("rust-embed", "5"),
-    ];
+    // symlink any local directories so they work with the new project location
     let mut deps = match parsed_toml.dependencies {
         Some(deps) => deps,
         None => Default::default(),
     };
-    for (dep, version) in new_deps.into_iter() {
-        if !deps.contains_key(dep) {
-            deps.insert(
-                dep.to_string(),
-                cargo_toml2::Dependency::Full(cargo_toml2::DependencyFull {
-                    version: Some(version.to_string()),
-                    ..Default::default()
-                }),
-            );
-        } else {
-            // todo make sure that the deps versions here are compatible
-        }
-    }
-
-    // symlink any local directories so they work with the new project location
     let details = deps
         .iter_mut()
         // only full dependency descriptions (not simple version number)

--- a/turbolift_macros/src/lib.rs
+++ b/turbolift_macros/src/lib.rs
@@ -43,7 +43,7 @@ pub fn on(distribution_platform_: TokenStream, function_: TokenStream) -> TokenS
     let sanitized_file = extract_function::get_sanitized_file(&function);
     // todo make code below hygienic in case sanitized_file also imports from actix_web
     let main_file = quote! {
-        use actix_web::{get, web, HttpResponse, Result};
+        use turbolift::actix_web::{self, get, web, HttpResponse, Result};
 
         #sanitized_file
         #dummy_function
@@ -57,7 +57,7 @@ pub fn on(distribution_platform_: TokenStream, function_: TokenStream) -> TokenS
             )
         }
 
-        #[actix_rt::main]
+        #[actix_web::main]
         async fn main() -> std::io::Result<()> {
             use actix_web::{App, HttpServer};
 


### PR DESCRIPTION
This PR reexports runtime reqs from turbolift instead of editing microservice manifest deps list. This means that the microservice can use the exact same deps list as the parent project. 

In the future, we might decide to split the API for re-exported stuff from the API for new stuff, so that it's less confusing for users. That's not prio for me right now though. 

Note: I also updated to actix 3 here at the same time.