### PR TITLE
add distributed feature flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,13 @@ jobs:
       run: rustup update
     - name: Format
       run: RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo fmt
-    - name: Check30
+    - name: Check without distributed feature
       run: RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo check
+    - name: Check with distributed feature
+      run: RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo check --features "distributed"
     - name: Clippy
       run: RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo clippy -- -D warnings
-    - name: Local Queue
+    - name: Local Queue without distributed feature
       run: cd examples/local_queue_example && RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test
-
+    - name: Local Queue with distributed feature
+      run: cd examples/local_queue_example && RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo test --features "distributed"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,10 @@
             language: system
             types: [ rust ]
             pass_filenames: false
+        -   id: check
+            name: Check
+            description: Runs `cargo check` on the repository with distributed flag
+            entry: bash -c 'RUSTFLAGS='"'"'--cfg procmacro2_semver_exempt'"'"' cargo check --features "distributed" "$@"' --
+            language: system
+            types: [ rust ]
+            pass_filenames: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,16 @@ description = "WIP"
 readme = "README.md"
 license = "Hippocratic-2.1"
 
+[features]
+distributed = ["chrono", "cached", "async-std"]
+service = ["actix-web", "serde_json"]
+# todo we can optimize reqs for children with this load
+
 [dependencies]
-turbolift_macros = { path="./turbolift_macros" }
-turbolift_internals = { path="./turbolift_internals" }
-async-std = { version="1.6" }
-chrono = "0.4"
-cached = "0.19"
-actix-web = "3"
-serde_json = "1"
+turbolift_macros = { path = "./turbolift_macros" }
+turbolift_internals = { path = "./turbolift_internals" }
+async-std = { version = "1.6", optional = true }
+chrono = { version = "0.4", optional = true }
+cached = { version = "0.19", optional = true }
+actix-web = { version = "3", optional = true }
+serde_json = { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -64,3 +64,5 @@ build any microservices or alter any code.
 
 ## Current tech debt todo
 - [ ] start reducing ginormous API, right now basically everything is public
+- [ ] refactor split between turbolift_internals and turbolift_macros
+- [ ] improve names

--- a/examples/local_queue_example/Cargo.toml
+++ b/examples/local_queue_example/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Dominic Burkart <1351120+DominicBurkart@users.noreply.github.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+"distributed" = ["turbolift/distributed"]
 
 [dependencies]
 rand = "0.7"

--- a/examples/local_queue_example/Dockerfile
+++ b/examples/local_queue_example/Dockerfile
@@ -3,3 +3,4 @@ FROM rustlang/rust:nightly
 COPY ./ ./
 WORKDIR examples/local_queue_example
 RUN RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo +nightly test
+RUN RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo +nightly test --features "distributed"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,15 @@
-pub use actix_web;
+#[cfg(feature = "distributed")]
 pub use async_std;
+#[cfg(feature = "distributed")]
 pub use cached;
+#[cfg(feature = "distributed")]
 pub use chrono;
+
+#[cfg(feature = "service")]
+pub use actix_web;
+#[cfg(feature = "service")]
 pub use serde_json;
-pub use turbolift_internals::*;
-pub use turbolift_macros::*;
 
 pub use distributed_platform::{DistributionPlatform, DistributionResult};
+pub use turbolift_internals::*;
+pub use turbolift_macros::*;

--- a/turbolift_internals/src/build_project.rs
+++ b/turbolift_internals/src/build_project.rs
@@ -102,7 +102,7 @@ pub fn lint(proj_path: &Path) -> anyhow::Result<()> {
 pub fn make_executable(proj_path: &Path, dest: Option<&Path>) -> anyhow::Result<()> {
     let status = Command::new("cargo")
         .current_dir(proj_path)
-        .args("build --release".split(' '))
+        .args("build --release --features \"distributed,service\"".split(' '))
         .status()?;
 
     if !status.success() {


### PR DESCRIPTION
adds `--features "distributed"` and `--features "service"`. When the distributed flag is not activated, any tagged functions are turned async but otherwise untouched (no microservices are generated). 

This helps now by avoiding building the `on` proc macro or compiling any of the distribution code while in development, and will be useful later when working on decreasing compilation time.