### PR TITLE
remove build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-cfg=procmacro2_semver_exempt");
-}


### PR DESCRIPTION
I don't think this is necessary and I suspect the issues that I am seeing trying to use the crates.io version of turbolift are happening because of weird build stuff.