### PR TITLE
update type signature for DeployContainerFunction

### DIFF
--- a/examples/kubernetes_example/src/main.rs
+++ b/examples/kubernetes_example/src/main.rs
@@ -25,7 +25,7 @@ lazy_static! {
 /// a function that is called after the container is
 /// built, so that the container may be added to a
 /// specific registry or otherwise be made available.
-fn load_container_into_kind(tag: &str) -> anyhow::Result<&str> {
+fn load_container_into_kind(tag: String) -> anyhow::Result<String> {
     std::process::Command::new("kind")
         .args(format!("load docker-image {}", tag).as_str().split(' '))
         .status()?;

--- a/turbolift_internals/src/kubernetes.rs
+++ b/turbolift_internals/src/kubernetes.rs
@@ -23,7 +23,7 @@ use crate::CACHE_PATH;
 
 const TURBOLIFT_K8S_NAMESPACE: &str = "default";
 type ImageTag = String;
-type DeployContainerFunction = Box<dyn Fn(&str) -> anyhow::Result<&str> + Send + 'static>;
+type DeployContainerFunction = Box<dyn Fn(String) -> anyhow::Result<String> + Send + 'static>;
 
 pub const CONTAINER_PORT: i32 = 5678;
 pub const SERVICE_PORT: i32 = 5678;
@@ -390,7 +390,7 @@ CMD [\"./{function_name}\", \"0.0.0.0:{container_port}\"]",
     // always remove the build directory, even on build error
     std::fs::remove_dir_all(build_dir_canonical)?;
 
-    result.and((k8s.deploy_container)(unique_tag.as_str()).map(|s| s.to_string()))
+    result.and((k8s.deploy_container)(unique_tag))
 }
 
 impl Drop for K8s {


### PR DESCRIPTION
we're seeing weird sizing errors in the version of turbolift pushed to crates.io as 0.1.2 that seem like they could be resolved by taking ownership of the input parameter (&str -> String). 