### PR TITLE
refactor fs use

### DIFF
--- a/turbolift_internals/Cargo.toml
+++ b/turbolift_internals/Cargo.toml
@@ -39,6 +39,8 @@ tracing = {version="0.1", features=["attributes"]}
 tracing-futures = "0.2.4"
 uuid = { version="0.8", features=["v4"] }
 derivative = "2.2.0"
+pathdiff = "0.2.0"
+include_dir = "0.6.1"
 
 # kubernetes-specific requirements
 kube = "0.51.0"

--- a/turbolift_internals/src/extract_function.rs
+++ b/turbolift_internals/src/extract_function.rs
@@ -129,8 +129,7 @@ pub fn params_json_vec(untyped_params: UntypedParams) -> TokenStream2 {
 #[tracing::instrument]
 pub fn get_sanitized_file(function: &TokenStream2) -> TokenStream2 {
     let span = function.span();
-    let path = fs::canonicalize(span.source_file().path())
-        .expect("get_sanitized_file: could not canonicalize source span file path.");
+    let path = span.source_file().path();
     let start_line = match span.start().line {
         0 => 0,
         1 => 0,
@@ -143,13 +142,7 @@ pub fn get_sanitized_file(function: &TokenStream2) -> TokenStream2 {
         panic!("File path for the targeted function does not exist: {:?} does the compiler support getting the TokenStream from a path?", path);
     }
     let file_contents = PROJECT_DIR
-        .get_file(
-            pathdiff::diff_paths(
-                path,
-                fs::canonicalize(".").expect("code directory cannot be found"),
-            )
-            .expect("get_sanitized_file: could not find the relative path of source code"),
-        )
+        .get_file(path)
         .expect("get_sanitized_file: could not locate source code within file store")
         .contents_utf8()
         .expect("get_sanitized_file: could not decode source code from file store");

--- a/turbolift_internals/src/extract_function.rs
+++ b/turbolift_internals/src/extract_function.rs
@@ -129,7 +129,8 @@ pub fn params_json_vec(untyped_params: UntypedParams) -> TokenStream2 {
 #[tracing::instrument]
 pub fn get_sanitized_file(function: &TokenStream2) -> TokenStream2 {
     let span = function.span();
-    let path = span.source_file().path();
+    let path = fs::canonicalize(span.source_file().path())
+        .expect("get_sanitized_file: could not canonicalize source span file path.");
     let start_line = match span.start().line {
         0 => 0,
         1 => 0,

--- a/turbolift_internals/src/lib.rs
+++ b/turbolift_internals/src/lib.rs
@@ -1,5 +1,8 @@
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate include_dir;
+
 use std::path::Path;
 
 pub mod build_project;


### PR DESCRIPTION
Right now, we are doing a lot of reads and writes to the file system, which may be problematic with the current state of procedural macros. This PR is focused on minimizing unnecessary FS activity and using more stable means to access the FS (e.g. via macros like `include_str!` instead of by opening and reading files).

As a bonus, we expect this to reduce compile time.