### PR TITLE
rename constructor

### DIFF
--- a/examples/kubernetes_example/src/main.rs
+++ b/examples/kubernetes_example/src/main.rs
@@ -13,10 +13,7 @@ use turbolift::on;
 
 /// instantiate the global cluster manager
 lazy_static! {
-    static ref K8S: Mutex<K8s> = Mutex::new(K8s::with_deploy_function_and_max_replicas(
-        Box::new(load_container_into_kind),
-        2
-    ));
+    static ref K8S: Mutex<K8s> = Mutex::new(K8s::new(Box::new(load_container_into_kind), 2));
 }
 
 /// The application writer is responsible for placing

--- a/turbolift_internals/src/kubernetes.rs
+++ b/turbolift_internals/src/kubernetes.rs
@@ -71,10 +71,7 @@ impl K8s {
     /// The deploy container function is used for making containers accessible
     /// to the cluster. See [`K8s::deploy_container`].
     #[tracing::instrument(skip(deploy_container))]
-    pub fn with_deploy_function_and_max_replicas(
-        deploy_container: DeployContainerFunction,
-        max: u32,
-    ) -> K8s {
+    pub fn new(deploy_container: DeployContainerFunction, max: u32) -> K8s {
         if max < 1 {
             panic!("max < 1 while instantiating k8s (value: {})", max)
         }


### PR DESCRIPTION
`with_deploy_function_and_max_replicas` is unnecessarily long.